### PR TITLE
增加双导师版封面支持

### DIFF
--- a/shtthesis-user-guide.tex
+++ b/shtthesis-user-guide.tex
@@ -532,6 +532,16 @@
 }
 \end{latex}
 
+如果论文封面需要同时呈现两位导师及他/她们的工作单位，可以参考本次 pull request 中更新的 shtthesis.cls，在保持原有功能不变的情况下，增加了双导师封面（中英文）的支持。在使用该版 shtthesis.cls 的同时，在 .tex 文件的声明部分添加双导师的声明，例如：
+
+\begin{latex}
+  % 提供双导师版封面
+  cosupervisor = {企业导师姓名}, 
+  cosupervisor* = {ndustry Mentor Name},
+  cosupervisor-institution = {上海联影医疗科技股份有限公司},
+  cosupervisor-institution* = {Shanghai United Imaging Medical Technology Co., Ltd.},
+\end{latex}
+
 \subsection{成文日期}
 通过 date 和 date* 分别设置中英文成文日期，日期内容应按照申请学位的时间节点填写，具体请参考当年《规范》。研究生成文日期格式为：
 \begin{latex}

--- a/shtthesis-user-guide.tex
+++ b/shtthesis-user-guide.tex
@@ -434,7 +434,7 @@
   supervisor* = {Professor~Fan~Rui},
   supervisor-institution = {上海科技大学信息科学与技术学院},
   % cosupervisor = {企业导师姓名}, % 提供双导师支持，注意使用修改版的 shtthesis.cls
-  % cosupervisor* = {ndustry Mentor Name},
+  % cosupervisor* = {Industry Mentor Name},
   % cosupervisor-institution = {上海联影医疗科技股份有限公司},
   % cosupervisor-institution* = {Shanghai United Imaging Medical Technology Co., Ltd.}
   discipline-level-1 = {计算机科学与技术},

--- a/shtthesis-user-guide.tex
+++ b/shtthesis-user-guide.tex
@@ -33,7 +33,7 @@
   supervisor* = {Professor~Fan~Rui},
   supervisor-institution = {上海科技大学信息科学与技术学院},
   % cosupervisor = {企业导师姓名}, % 提供双导师版封面
-  % cosupervisor* = {ndustry Mentor Name},
+  % cosupervisor* = {Industry Mentor Name},
   % cosupervisor-institution = {上海联影医疗科技股份有限公司},
   % cosupervisor-institution* = {Shanghai United Imaging Medical Technology Co., Ltd.},
   discipline-level-1 = {计算机科学与技术},
@@ -433,6 +433,10 @@
   supervisor = {范睿~副教授},
   supervisor* = {Professor~Fan~Rui},
   supervisor-institution = {上海科技大学信息科学与技术学院},
+  % cosupervisor = {企业导师姓名}, % 提供双导师支持，注意使用修改版的 shtthesis.cls
+  % cosupervisor* = {ndustry Mentor Name},
+  % cosupervisor-institution = {上海联影医疗科技股份有限公司},
+  % cosupervisor-institution* = {Shanghai United Imaging Medical Technology Co., Ltd.}
   discipline-level-1 = {计算机科学与技术},
   discipline-level-1* = {Computer~Science~and~Technology},
   date = {2020~年~6~月},
@@ -440,6 +444,7 @@
   bib-resource = {reference.bib},
 }
 \end{latex}
+
 
 本科生论文信息设定样例为：
 \begin{latex}
@@ -537,9 +542,9 @@
 \begin{latex}
   % 提供双导师版封面
   cosupervisor = {企业导师姓名}, 
-  cosupervisor* = {ndustry Mentor Name},
+  cosupervisor* = {Industry Mentor Name},
   cosupervisor-institution = {上海联影医疗科技股份有限公司},
-  cosupervisor-institution* = {Shanghai United Imaging Medical Technology Co., Ltd.},
+  cosupervisor-institution* = {Shanghai United Imaging Medical Technology Co., Ltd.}
 \end{latex}
 
 \subsection{成文日期}

--- a/shtthesis-user-guide.tex
+++ b/shtthesis-user-guide.tex
@@ -32,6 +32,10 @@
   supervisor = {范睿~副教授},
   supervisor* = {Professor~Fan~Rui},
   supervisor-institution = {上海科技大学信息科学与技术学院},
+  % cosupervisor = {企业导师姓名}, % 提供双导师版封面
+  % cosupervisor* = {ndustry Mentor Name},
+  % cosupervisor-institution = {上海联影医疗科技股份有限公司},
+  % cosupervisor-institution* = {Shanghai United Imaging Medical Technology Co., Ltd.},
   discipline-level-1 = {计算机科学与技术},
   discipline-level-1* = {Computer~Science~and~Technology},
   bib-resource = {reference.bib},

--- a/shtthesis.cls
+++ b/shtthesis.cls
@@ -170,15 +170,28 @@
   supervisor = {
     default = {导师姓名},
   },
+  cosupervisor = {
+    default = {},
+  },
   supervisor* = {
     default = {Name of supervisor},
     name    = supervisor@en,
   },
+  cosupervisor* = {
+    default = {},
+    name    = cosupervisor@en,
+  },
   supervisor-institution = {
     name = supervisor@institution,
   },
+  cosupervisor-institution = {
+    name = cosupervisor@institution,
+  },
   supervisor-institution* = {
     name = supervisor@institution@en,
+  },
+  cosupervisor-institution* = {
+    name = cosupervisor@institution@en,
   },
   institution = {
     % default = {上海科技大学信息科学与技术学院},
@@ -300,7 +313,6 @@
   gbpub = false,
   gbcitelocal = chinese,
   sortcites = false,
-  mergedate = none,
 }{biblatex}
 \LoadClass{ctexbook}
 \RequirePackage{expl3}
@@ -1207,16 +1219,45 @@
             \fi%
           }}} \\
         指导教师：&
+        \ifdefempty{\sht@cosupervisor}{
           \multicolumn{2}{c}{\shifted@uline{\shifted@box{%
-            \ifsht@anonymous%
-              \sht@anonymous@str%
-            \else%
-              \sht@supervisor%
-            \fi%
-          }}} \\
+          \ifsht@anonymous%
+            \sht@anonymous@str%
+          \else%
+            \sht@supervisor%
+          \fi%
+        }}} \\
         \ifdefempty{\sht@supervisor@institution}{}{ &
           \multicolumn{2}{c}{\shifted@uline{%
             \shifted@box{\sht@supervisor@institution}}} \\
+        }
+        }{
+          \multicolumn{2}{c}{\shifted@uline{%
+              \shifted@box{
+                \ifsht@anonymous%
+                  \sht@anonymous@str
+                \else
+                \ifdef{\sht@supervisor@institution}{
+                  \sht@supervisor~\sht@supervisor@institution
+                }{
+                  \sht@supervisor
+                }
+                \fi
+              }
+            }} \\
+          & \multicolumn{2}{c}{\shifted@uline{%
+              \shifted@box{
+                \ifsht@anonymous%
+                  \sht@anonymous@str
+                \else
+                  \ifdef{\sht@cosupervisor@institution}{
+                    \sht@cosupervisor~\sht@cosupervisor@institution
+                  }{ 
+                    \sht@cosupervisor
+                  }
+                \fi
+              }
+            }} \\
         }
         学位类别：&
           \multicolumn{2}{c}{\shifted@uline{\shifted@box{\sht@degree@name}}} \\
@@ -1276,7 +1317,11 @@
       \ifsht@anonymous%
         \sht@anonymous@str%
       \else%
-        \sht@supervisor@en%
+        \ifdefempty{\sht@cosupervisor@en}{
+          \sht@supervisor@en
+        }{
+          \sht@supervisor@en, \sht@cosupervisor@en
+        }
       \fi%
     }
 


### PR DESCRIPTION
参考 #14 中润东建议的呈现方案1，修改了 shtthesis.cls，在保持原有功能不变的前提下增加了双导师版封面的支持。
如果需要双导师版中英文封面，可使用这一版 shtthesis.cls，并在 tex 的导言区添加
```latex
cosupervisor = {企业导师姓名}, 
cosupervisor* = {Industry Mentor Name},
cosupervisor-institution = {上海联影医疗科技股份有限公司},
cosupervisor-institution* = {Shanghai United Imaging Medical Technology Co., Ltd.}
```
即可呈现双导师版的中英文封面
>相关功能在 Windows11+XeLaTeX 的编译环境中，分别测试了单导师（导师姓名和单位分两行）和双导师（每位导师姓名+单位占一行）以及盲审版封面生成，均正常。但不能保证在所有情况下都能呈现正常结果，仅供参考，欢迎大家反馈问题，也请润东谨慎合并。